### PR TITLE
Respect asynchronous exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# hpqtypes-1.5.3.0 (2018-06-04)
+* add INLINE/INLINEABLE pragmas for call site specialization
+* remove -O2 -funbox-strict-fields from ghc-options
+* make query execution interruptible with asynchronous exceptions
+* make connect interruptible with asynchronous exceptions
+
 # hpqtypes-1.5.2.0 (2018-03-18)
 * support GHC 8.4.1
 

--- a/hpqtypes.cabal
+++ b/hpqtypes.cabal
@@ -180,6 +180,7 @@ library
                     , GeneralizedNewtypeDeriving
                     , LambdaCase
                     , MultiParamTypeClasses
+                    , MultiWayIf
                     , NoImplicitPrelude
                     , OverloadedStrings
                     , RankNTypes
@@ -235,6 +236,7 @@ test-suite hpqtypes-tests
                     , GeneralizedNewtypeDeriving
                     , LambdaCase
                     , MultiParamTypeClasses
+                    , MultiWayIf
                     , NoImplicitPrelude
                     , OverloadedStrings
                     , RankNTypes

--- a/hpqtypes.cabal
+++ b/hpqtypes.cabal
@@ -1,5 +1,5 @@
 name:                hpqtypes
-version:             1.5.2.0
+version:             1.5.3.0
 synopsis:            Haskell bindings to libpqtypes
 
 description:         Efficient and easy-to-use bindings to (slightly modified)
@@ -79,7 +79,7 @@ source-repository head
 source-repository this
   type:     git
   location: https://github.com/scrive/hpqtypes.git
-  tag:      1.5.2.0
+  tag:      1.5.3.0
 
 library
   exposed-modules:     Data.Monoid.Utils

--- a/hpqtypes.cabal
+++ b/hpqtypes.cabal
@@ -122,6 +122,7 @@ library
   build-depends:       base >= 4.7 && < 4.12
                      , text >= 0.11
                      , aeson >= 0.6.2.0
+                     , async >= 2.1.1.1
                      , bytestring >= 0.9
                      , semigroups >= 0.16
                      , time >= 1.4
@@ -177,6 +178,7 @@ library
                     , ForeignFunctionInterface
                     , GADTs
                     , GeneralizedNewtypeDeriving
+                    , LambdaCase
                     , MultiParamTypeClasses
                     , NoImplicitPrelude
                     , OverloadedStrings
@@ -231,6 +233,7 @@ test-suite hpqtypes-tests
                     , ForeignFunctionInterface
                     , GADTs
                     , GeneralizedNewtypeDeriving
+                    , LambdaCase
                     , MultiParamTypeClasses
                     , NoImplicitPrelude
                     , OverloadedStrings

--- a/src/Database/PostgreSQL/PQTypes/Internal/C/Types.hsc
+++ b/src/Database/PostgreSQL/PQTypes/Internal/C/Types.hsc
@@ -9,6 +9,9 @@ module Database.PostgreSQL.PQTypes.Internal.C.Types (
   , c_CONNECTION_OK, c_CONNECTION_BAD, c_CONNECTION_STARTED
   , c_CONNECTION_MADE, c_CONNECTION_AWAITING_RESPONSE, c_CONNECTION_AUTH_OK
   , c_CONNECTION_SETENV, c_CONNECTION_SSL_STARTUP, c_CONNECTION_NEEDED
+  , PostgresPollingStatusType(..)
+  , c_PGRES_POLLING_FAILED, c_PGRES_POLLING_READING, c_PGRES_POLLING_WRITING
+  , c_PGRES_POLLING_OK, c_PGRES_POLLING_ACTIVE
   , ResultFormat(..)
   , c_RESULT_TEXT, c_RESULT_BINARY
   , ExecStatusType(..)
@@ -70,6 +73,19 @@ newtype ConnStatusType = ConnStatusType CInt
 , c_CONNECTION_SSL_STARTUP = CONNECTION_SSL_STARTUP
 , c_CONNECTION_NEEDED = CONNECTION_NEEDED
 }
+
+----------------------------------------
+
+newtype PostgresPollingStatusType = PostgresPollingStatusType CInt
+  deriving Eq
+
+#{enum PostgresPollingStatusType, PostgresPollingStatusType
+ , c_PGRES_POLLING_FAILED  = PGRES_POLLING_FAILED
+ , c_PGRES_POLLING_READING = PGRES_POLLING_READING
+ , c_PGRES_POLLING_WRITING = PGRES_POLLING_WRITING
+ , c_PGRES_POLLING_OK      = PGRES_POLLING_OK
+ , c_PGRES_POLLING_ACTIVE  = PGRES_POLLING_ACTIVE
+ }
 
 ----------------------------------------
 

--- a/src/Database/PostgreSQL/PQTypes/Internal/C/Types.hsc
+++ b/src/Database/PostgreSQL/PQTypes/Internal/C/Types.hsc
@@ -1,6 +1,7 @@
 -- | Mappings of types used by libpq/libpqtypes to Haskell ADTs.
 module Database.PostgreSQL.PQTypes.Internal.C.Types (
-    PGconn
+    PGcancel
+  , PGconn
   , PGparam
   , PGresult
   , PGtypeArgs
@@ -44,6 +45,7 @@ import qualified Data.Vector.Storable as V
 
 #let alignment t = "%lu", (unsigned long)offsetof(struct {char x__; t (y__);}, y__)
 
+data PGcancel
 data PGconn
 data PGparam
 data PGresult

--- a/src/Database/PostgreSQL/PQTypes/Internal/Query.hs
+++ b/src/Database/PostgreSQL/PQTypes/Internal/Query.hs
@@ -3,6 +3,8 @@ module Database.PostgreSQL.PQTypes.Internal.Query (
   ) where
 
 import Control.Applicative
+import Control.Concurrent.Async
+import Control.Monad
 import Foreign.ForeignPtr
 import Foreign.Ptr
 import Prelude
@@ -24,28 +26,55 @@ import Database.PostgreSQL.PQTypes.ToSQL
 -- | Low-level function for running SQL query.
 runQueryIO :: IsSQL sql => sql -> DBState m -> IO (Int, DBState m)
 runQueryIO sql st = do
-  (affected, res) <- withConnectionData (dbConnection st) "runQueryIO" $ \cd -> do
-    let ConnectionData{..} = cd
-        allocParam = ParamAllocator $ withPGparam cdPtr
-    (paramCount, res) <- withSQL sql allocParam $ \param query -> (,)
-      <$> (fromIntegral <$> c_PQparamCount param)
-      <*> c_PQparamExec cdPtr nullPtr param query c_RESULT_BINARY
-    affected <- withForeignPtr res $ verifyResult cdPtr
-    stats' <- case affected of
-      Left _ -> return cdStats {
-        statsQueries = statsQueries cdStats + 1
-      , statsParams  = statsParams cdStats + paramCount
-      }
-      Right rows -> do
-        columns <- fromIntegral <$> withForeignPtr res c_PQnfields
-        return ConnectionStats {
+  (affected, res) <- withConnDo $ \cd@ConnectionData{..} -> E.mask $ \restore -> do
+    -- While the query runs, the current thread will not be able to receive
+    -- asynchronous exceptions. This prevents clients of the library from
+    -- interrupting execution of the query. To remedy that we spawn a separate
+    -- thread for the query execution and while we wait for its completion, we
+    -- are able to receive asynchronous exceptions (assuming that threaded GHC
+    -- runtime system is used) and react appropriately.
+    queryRunner <- async . restore $ do
+      let allocParam = ParamAllocator $ withPGparam cdPtr
+      (paramCount, res) <- withSQL sql allocParam $ \param query -> (,)
+        <$> (fromIntegral <$> c_PQparamCount param)
+        <*> c_PQparamExec cdPtr nullPtr param query c_RESULT_BINARY
+      affected <- withForeignPtr res $ verifyResult cdPtr
+      stats' <- case affected of
+        Left _ -> return cdStats {
           statsQueries = statsQueries cdStats + 1
-        , statsRows    = statsRows cdStats + rows
-        , statsValues  = statsValues cdStats + (rows * columns)
         , statsParams  = statsParams cdStats + paramCount
         }
-    -- Force evaluation of modified stats to squash space leak.
-    stats' `seq` return (cd { cdStats = stats' }, (either id id affected, res))
+        Right rows -> do
+          columns <- fromIntegral <$> withForeignPtr res c_PQnfields
+          return ConnectionStats {
+            statsQueries = statsQueries cdStats + 1
+          , statsRows    = statsRows cdStats + rows
+          , statsValues  = statsValues cdStats + (rows * columns)
+          , statsParams  = statsParams cdStats + paramCount
+          }
+      -- Force evaluation of modified stats to squash a space leak.
+      stats' `seq` return (cd { cdStats = stats' }, (either id id affected, res))
+    -- If we receive an exception while waiting for the execution to complete,
+    -- we need to send a request to PostgreSQL for query cancellation and wait
+    -- for the query runner thread to terminate. It is paramount we make the
+    -- exception handler uninterruptible as we can't exit from the main block
+    -- until the query runner thread has terminated.
+    E.onException (restore $ wait queryRunner) . E.uninterruptibleMask_ $ do
+      c_PQcancel cdPtr >>= \case
+        -- If query cancellation request was successfully processed, there is
+        -- nothing else to do apart from waiting for the runner to terminate.
+        Nothing -> cancel queryRunner
+        -- Otherwise we check what happened with the runner. If it already
+        -- finished we're fine, just ignore the result. If it didn't, there is
+        -- something wrong - cancellation request didn't go through, yet the
+        -- query is still running? It's not clear how this might happen, but in
+        -- such case we must wait for its completion anyway.
+        Just err -> poll queryRunner >>= \case
+          Just _  -> return ()
+          Nothing -> do
+            cancel queryRunner
+            rethrowWithContext sql . E.toException $
+              HPQTypesError ("PQcancel failed: " ++ err)
   return (affected, st {
     dbLastQuery = SomeSQL sql
   , dbQueryResult = Just QueryResult {
@@ -55,6 +84,8 @@ runQueryIO sql st = do
     }
   })
   where
+    withConnDo = withConnectionData (dbConnection st) "runQueryIO"
+
     verifyResult :: Ptr PGconn -> Ptr PGresult -> IO (Either Int Int)
     verifyResult conn res = do
       -- works even if res is NULL


### PR DESCRIPTION
Modify:
* `runQueryIO` to be able to receive asynchronous exceptions during query execution and cancel it
* `connect` to be able to receive asynchronous exceptions while a connection is being initialized