### PR TITLE
Implement UUID format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# hpqtypes-1.8.0.0 (2019-10-28)
+* Implement `UUID` format ([#17](https://github.com/scrive/hpqtypes/pull/17)).
+
 # hpqtypes-1.7.0.0 (2019-05-21)
 * Remove the `Default` instances for `ConnectionSettings` and
   `TransactionSettings`; use `defaultConnectionSettings` and

--- a/hpqtypes.cabal
+++ b/hpqtypes.cabal
@@ -1,5 +1,5 @@
 name:                hpqtypes
-version:             1.7.0.0
+version:             1.8.0.0
 synopsis:            Haskell bindings to libpqtypes
 
 description:         Efficient and easy-to-use bindings to (slightly modified)
@@ -140,6 +140,7 @@ library
                      , containers        >= 0.5.0.0
                      , exceptions        >= 0.6
                      , text-show         >= 2
+                     , uuid              >= 1.3      && < 1.4
 
   hs-source-dirs:    src
 
@@ -225,6 +226,7 @@ test-suite hpqtypes-tests
                      , transformers-base >= 0.4
                      , unordered-containers
                      , vector
+                     , uuid
 
   default-language:  Haskell2010
   default-extensions: BangPatterns

--- a/hpqtypes.cabal
+++ b/hpqtypes.cabal
@@ -140,7 +140,7 @@ library
                      , containers        >= 0.5.0.0
                      , exceptions        >= 0.6
                      , text-show         >= 2
-                     , uuid              >= 1.3      && < 1.4
+                     , uuid-types        >= 1.0.3   && < 1.1
 
   hs-source-dirs:    src
 
@@ -226,7 +226,7 @@ test-suite hpqtypes-tests
                      , transformers-base >= 0.4
                      , unordered-containers
                      , vector
-                     , uuid
+                     , uuid-types
 
   default-language:  Haskell2010
   default-extensions: BangPatterns

--- a/libpqtypes/src/libpqtypes.h
+++ b/libpqtypes/src/libpqtypes.h
@@ -148,7 +148,19 @@ struct pg_typeargs
 typedef char *PGtext;
 typedef char *PGvarchar;
 typedef char *PGbpchar;
-typedef char *PGuuid;
+
+typedef union
+{
+	struct
+	{
+		unsigned w1;
+		unsigned w2;
+		unsigned w3;
+		unsigned w4;
+	};
+	char data[16];
+} PGuuid;
+
 typedef struct
 {
   int len;

--- a/src/Database/PostgreSQL/PQTypes/Format.hs
+++ b/src/Database/PostgreSQL/PQTypes/Format.hs
@@ -13,6 +13,7 @@ import Data.Int
 import Data.Proxy
 import Data.Time
 import Data.Word
+import Data.UUID
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import qualified Data.Text as T
@@ -102,6 +103,9 @@ instance PQFormat T.Text where
 
 instance PQFormat TL.Text where
   pqFormat = BS.pack "%btext"
+
+instance PQFormat UUID where
+  pqFormat = BS.pack "%uuid"
 
 -- BYTEA
 

--- a/src/Database/PostgreSQL/PQTypes/Format.hs
+++ b/src/Database/PostgreSQL/PQTypes/Format.hs
@@ -13,7 +13,7 @@ import Data.Int
 import Data.Proxy
 import Data.Time
 import Data.Word
-import Data.UUID
+import Data.UUID.Types
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import qualified Data.Text as T

--- a/src/Database/PostgreSQL/PQTypes/FromSQL.hs
+++ b/src/Database/PostgreSQL/PQTypes/FromSQL.hs
@@ -15,7 +15,7 @@ import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
-import qualified Data.UUID as U
+import qualified Data.UUID.Types as U
 
 import Database.PostgreSQL.PQTypes.Format
 import Database.PostgreSQL.PQTypes.Internal.C.Types

--- a/src/Database/PostgreSQL/PQTypes/FromSQL.hs
+++ b/src/Database/PostgreSQL/PQTypes/FromSQL.hs
@@ -8,7 +8,6 @@ import Data.Text.Encoding
 import Data.Time
 import Data.Word
 import Foreign.C
-import Foreign.Ptr
 import Foreign.Storable
 import qualified Control.Exception as E
 import qualified Data.ByteString.Char8 as BS
@@ -98,12 +97,9 @@ instance FromSQL String where
   fromSQL mbytea = T.unpack <$> fromSQL mbytea
 
 instance FromSQL U.UUID where
-  -- pqt_get_uuid expects **char consist of 16 bytes of data
-  type PQBase U.UUID = Ptr PGuuid
+  type PQBase U.UUID = PGuuid
   fromSQL Nothing = unexpectedNULL
-  fromSQL (Just wordsPtr) = do
-    (PGuuid w1 w2 w3 w4) <- peek wordsPtr
-    return $ U.fromWords w1 w2 w3 w4
+  fromSQL (Just (PGuuid w1 w2 w3 w4)) = return $ U.fromWords w1 w2 w3 w4
 
 -- BYTEA
 

--- a/src/Database/PostgreSQL/PQTypes/Internal/C/Types.hsc
+++ b/src/Database/PostgreSQL/PQTypes/Internal/C/Types.hsc
@@ -30,11 +30,14 @@ module Database.PostgreSQL.PQTypes.Internal.C.Types (
   , PGregisterType(..)
   , PGarray(..)
   , PGbytea(..)
+  , PGuuid(..)
   , PGdate(..)
   , PGtime(..)
   , PGtimestamp(..)
   ) where
 
+import Data.Bits
+import Data.Word
 import Data.ByteString.Unsafe
 import Foreign.C
 import Foreign.ForeignPtr
@@ -235,6 +238,62 @@ instance Storable PGbytea where
     #{poke PGbytea, data} ptr pgByteaData
 
 ----------------------------------------
+
+-- PGuuid C type is *char, but in actual expects the array
+-- to be 16 bytes. The bytes are encoded directly from the
+-- hex representation of the UUID, which is different from
+-- the default binary encoding from Data.UUID.
+data PGuuid = PGuuid {
+  w1 :: !Word32,
+  w2 :: !Word32,
+  w3 :: !Word32,
+  w4 :: !Word32
+} deriving Show
+
+instance Storable PGuuid where
+  sizeOf _ = 16
+  alignment _ = 4
+
+  peekByteOff p off =
+    PGuuid
+      <$> peekWord32Off p off
+      <*> peekWord32Off p (off+4)
+      <*> peekWord32Off p (off+8)
+      <*> peekWord32Off p (off+12)
+    where
+      peekWord8Off :: Ptr a -> Int -> IO Word8
+      peekWord8Off = peekByteOff
+
+      peekWord32Off :: Ptr a -> Int -> IO Word32
+      peekWord32Off p' off' = do
+        b1 <- fromIntegral <$> peekWord8Off p' off'
+        b2 <- fromIntegral <$> peekWord8Off p' (off'+1)
+        b3 <- fromIntegral <$> peekWord8Off p' (off'+2)
+        b4 <- fromIntegral <$> peekWord8Off p' (off'+3)
+        return $
+          (b1 `shiftL` 24) .|.
+          (b2 `shiftL` 16) .|.
+          (b3 `shiftL` 8) .|.
+          b4
+  {-# INLINE peekByteOff #-}
+
+  pokeByteOff p off (PGuuid w1 w2 w3 w4) =
+    do
+      pokeWord32Off p off w1
+      pokeWord32Off p (off+4) w2
+      pokeWord32Off p (off+8) w3
+      pokeWord32Off p (off+12) w4
+      where
+        pokeWord8Off :: Ptr a -> Int -> Word8 -> IO ()
+        pokeWord8Off = pokeByteOff
+
+        pokeWord32Off :: Ptr a -> Int -> Word32 -> IO ()
+        pokeWord32Off p' off' word = do
+          pokeWord8Off p' off' $ fromIntegral (word `shiftR` 24)
+          pokeWord8Off p' (off'+1) $ fromIntegral (word `shiftR` 16)
+          pokeWord8Off p' (off'+2) $ fromIntegral (word `shiftR` 8)
+          pokeWord8Off p' (off'+3) $ fromIntegral word
+  {-# INLINE pokeByteOff #-}
 
 data PGdate = PGdate {
   pgDateIsBC :: !CInt

--- a/src/Database/PostgreSQL/PQTypes/Internal/C/Types.hsc
+++ b/src/Database/PostgreSQL/PQTypes/Internal/C/Types.hsc
@@ -36,7 +36,6 @@ module Database.PostgreSQL.PQTypes.Internal.C.Types (
   , PGtimestamp(..)
   ) where
 
-import Data.Bits
 import Data.Word
 import Data.ByteString.Unsafe
 import Foreign.C
@@ -55,6 +54,9 @@ data PGtypeArgs
 
 #include <libpqtypes.h>
 #include <libpq-fe.h>
+
+foreign import ccall unsafe htonl :: Word32 -> Word32
+foreign import ccall unsafe ntohl :: Word32 -> Word32
 
 ----------------------------------------
 
@@ -239,61 +241,32 @@ instance Storable PGbytea where
 
 ----------------------------------------
 
--- PGuuid C type is *char, but in actual expects the array
--- to be 16 bytes. The bytes are encoded directly from the
--- hex representation of the UUID, which is different from
--- the default binary encoding from Data.UUID.
-data PGuuid = PGuuid {
-  w1 :: !Word32,
-  w2 :: !Word32,
-  w3 :: !Word32,
-  w4 :: !Word32
-} deriving Show
+-- Same as the UUID type from uuid-types package except for the Storable
+-- instance: PostgreSQL expects the binary representation to be encoded in
+-- network byte order (as per RFC 4122), whereas Storable instance of UUID
+-- preserves host byte order, so we need to have our own version.
+data PGuuid = PGuuid
+  { pgUuidW1 :: !Word32
+  , pgUuidW2 :: !Word32
+  , pgUuidW3 :: !Word32
+  , pgUuidW4 :: !Word32
+  } deriving Show
 
 instance Storable PGuuid where
-  sizeOf _ = 16
-  alignment _ = 4
+  sizeOf _ = #{size PGuuid}
+  alignment _ = #{alignment PGuuid}
 
-  peekByteOff p off =
-    PGuuid
-      <$> peekWord32Off p off
-      <*> peekWord32Off p (off+4)
-      <*> peekWord32Off p (off+8)
-      <*> peekWord32Off p (off+12)
-    where
-      peekWord8Off :: Ptr a -> Int -> IO Word8
-      peekWord8Off = peekByteOff
+  peek ptr = PGuuid
+    <$> (ntohl <$> #{peek PGuuid, w1} ptr)
+    <*> (ntohl <$> #{peek PGuuid, w2} ptr)
+    <*> (ntohl <$> #{peek PGuuid, w3} ptr)
+    <*> (ntohl <$> #{peek PGuuid, w4} ptr)
 
-      peekWord32Off :: Ptr a -> Int -> IO Word32
-      peekWord32Off p' off' = do
-        b1 <- fromIntegral <$> peekWord8Off p' off'
-        b2 <- fromIntegral <$> peekWord8Off p' (off'+1)
-        b3 <- fromIntegral <$> peekWord8Off p' (off'+2)
-        b4 <- fromIntegral <$> peekWord8Off p' (off'+3)
-        return $
-          (b1 `shiftL` 24) .|.
-          (b2 `shiftL` 16) .|.
-          (b3 `shiftL` 8) .|.
-          b4
-  {-# INLINE peekByteOff #-}
-
-  pokeByteOff p off (PGuuid w1 w2 w3 w4) =
-    do
-      pokeWord32Off p off w1
-      pokeWord32Off p (off+4) w2
-      pokeWord32Off p (off+8) w3
-      pokeWord32Off p (off+12) w4
-      where
-        pokeWord8Off :: Ptr a -> Int -> Word8 -> IO ()
-        pokeWord8Off = pokeByteOff
-
-        pokeWord32Off :: Ptr a -> Int -> Word32 -> IO ()
-        pokeWord32Off p' off' word = do
-          pokeWord8Off p' off' $ fromIntegral (word `shiftR` 24)
-          pokeWord8Off p' (off'+1) $ fromIntegral (word `shiftR` 16)
-          pokeWord8Off p' (off'+2) $ fromIntegral (word `shiftR` 8)
-          pokeWord8Off p' (off'+3) $ fromIntegral word
-  {-# INLINE pokeByteOff #-}
+  poke ptr PGuuid{..} = do
+    #{poke PGuuid, w1} ptr $ htonl pgUuidW1
+    #{poke PGuuid, w2} ptr $ htonl pgUuidW2
+    #{poke PGuuid, w3} ptr $ htonl pgUuidW3
+    #{poke PGuuid, w4} ptr $ htonl pgUuidW4
 
 data PGdate = PGdate {
   pgDateIsBC :: !CInt

--- a/src/Database/PostgreSQL/PQTypes/ToSQL.hs
+++ b/src/Database/PostgreSQL/PQTypes/ToSQL.hs
@@ -2,6 +2,7 @@ module Database.PostgreSQL.PQTypes.ToSQL (
     ParamAllocator(..)
   , ToSQL(..)
   , putAsPtr
+  , PGuuid (..)
   ) where
 
 import Data.ByteString.Unsafe
@@ -17,6 +18,7 @@ import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
+import qualified Data.UUID as U
 
 import Database.PostgreSQL.PQTypes.Format
 import Database.PostgreSQL.PQTypes.Internal.C.Interface
@@ -108,6 +110,14 @@ instance ToSQL TL.Text where
 instance ToSQL String where
   type PQDest String = PGbytea
   toSQL = toSQL . T.pack
+
+instance ToSQL U.UUID where
+  -- pqt_put_uuid expects a *char consist of 16 bytes of data
+  type PQDest U.UUID = PGuuid
+  toSQL uuid _ =
+    case U.toWords uuid of
+      (w1, w2, w3, w4) ->
+        putAsPtr $ PGuuid w1 w2 w3 w4
 
 -- BYTEA
 

--- a/src/Database/PostgreSQL/PQTypes/ToSQL.hs
+++ b/src/Database/PostgreSQL/PQTypes/ToSQL.hs
@@ -2,7 +2,6 @@ module Database.PostgreSQL.PQTypes.ToSQL (
     ParamAllocator(..)
   , ToSQL(..)
   , putAsPtr
-  , PGuuid (..)
   ) where
 
 import Data.ByteString.Unsafe
@@ -112,12 +111,10 @@ instance ToSQL String where
   toSQL = toSQL . T.pack
 
 instance ToSQL U.UUID where
-  -- pqt_put_uuid expects a *char consist of 16 bytes of data
   type PQDest U.UUID = PGuuid
-  toSQL uuid _ =
-    case U.toWords uuid of
-      (w1, w2, w3, w4) ->
-        putAsPtr $ PGuuid w1 w2 w3 w4
+  toSQL uuid _ = putAsPtr $ PGuuid w1 w2 w3 w4
+    where
+      (w1, w2, w3, w4) = U.toWords uuid
 
 -- BYTEA
 

--- a/src/Database/PostgreSQL/PQTypes/ToSQL.hs
+++ b/src/Database/PostgreSQL/PQTypes/ToSQL.hs
@@ -18,7 +18,7 @@ import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as BSL
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
-import qualified Data.UUID as U
+import qualified Data.UUID.Types as U
 
 import Database.PostgreSQL.PQTypes.Format
 import Database.PostgreSQL.PQTypes.Internal.C.Interface

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -430,7 +430,6 @@ uuidTest :: TestData -> Test
 uuidTest td = testCase "UUID encoding / decoding test" $ do
   let uuidStr = "550e8400-e29b-41d4-a716-446655440000"
       (Just uuid) = U.fromText uuidStr
-  liftBase . putStrLn $ "uuid: " <> T.unpack uuidStr
   runTestEnv td defaultTransactionSettings $ do
     runSQL_ $ mkSQL $ "SELECT '" <> uuidStr <> "' :: uuid"
     uuid2 <- fetchOne runIdentity

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -28,6 +28,7 @@ import Test.QuickCheck.Gen
 import TextShow
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
+import qualified Data.UUID as U
 
 import Data.Monoid.Utils
 import Database.PostgreSQL.PQTypes
@@ -425,6 +426,20 @@ putGetTest td n t eq = testCase
   v' <- fetchOne runIdentity
   assertEqual "Value doesn't change after getting through database" v v' eq
 
+uuidTest :: TestData -> Test
+uuidTest td = testCase "UUID encoding / decoding test" $ do
+  let uuidStr = "550e8400-e29b-41d4-a716-446655440000"
+      (Just uuid) = U.fromText uuidStr
+  liftBase . putStrLn $ "uuid: " <> T.unpack uuidStr
+  runTestEnv td defaultTransactionSettings $ do
+    runSQL_ $ mkSQL $ "SELECT '" <> uuidStr <> "' :: uuid"
+    uuid2 <- fetchOne runIdentity
+    assertEqual "UUID is decoded correctly" uuid uuid2 (==)
+
+    runQuery_ $ rawSQL " SELECT $1 :: text" (Identity uuid)
+    uuidStr2 <- fetchOne runIdentity
+    assertEqual "UUID is encoded correctly" uuidStr uuidStr2 (==)
+
 xmlTest :: TestData -> Test
 xmlTest td  = testCase "Put and get XML value works" .
               runTestEnv td defaultTransactionSettings $ do
@@ -467,7 +482,8 @@ tests td = [
   , notifyTest td
   , queryInterruptionTest td
   , cursorTest td
-  ----------------------------------------
+  , uuidTest td
+  ------------------------------------
   , transactionTest td ReadCommitted
   , transactionTest td RepeatableRead
   , transactionTest td Serializable
@@ -483,6 +499,7 @@ tests td = [
   , nullTest td (u::String)
   , nullTest td (u::BS.ByteString)
   , nullTest td (u::T.Text)
+  , nullTest td (u::U.UUID)
   , nullTest td (u::JSON Value)
   , nullTest td (u::JSONB Value)
   , nullTest td (u::XML)
@@ -508,6 +525,7 @@ tests td = [
   , putGetTest td 1000 (u::String0) (==)
   , putGetTest td 1000 (u::BS.ByteString) (==)
   , putGetTest td 1000 (u::T.Text) (==)
+  , putGetTest td 1000 (u::U.UUID) (==)
   , putGetTest td 50 (u::JSON Value) (==)
   , putGetTest td 50 (u::JSONB Value) (==)
   , putGetTest td 20 (u::Array1 (JSON Value)) (==)
@@ -577,8 +595,8 @@ tests td = [
   , rowTest td (u::(Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32, Composite Simple, CompositeArray1 Simple, Composite Nested, CompositeArray1 Nested, Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32, Composite Simple, CompositeArray1 Simple, Composite Nested, CompositeArray1 Nested, Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString))
   , rowTest td (u::(Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32, Composite Simple, CompositeArray1 Simple, Composite Nested, CompositeArray1 Nested, Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32, Composite Simple, CompositeArray1 Simple, Composite Nested, CompositeArray1 Nested, Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text))
   , rowTest td (u::(Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32, Composite Simple, CompositeArray1 Simple, Composite Nested, CompositeArray1 Nested, Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32, Composite Simple, CompositeArray1 Simple, Composite Nested, CompositeArray1 Nested, Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString))
-  , rowTest td (u::(Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32, Composite Simple, CompositeArray1 Simple, Composite Nested, CompositeArray1 Nested, Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32, Composite Simple, CompositeArray1 Simple, Composite Nested, CompositeArray1 Nested, Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day))
-  , rowTest td (u::(Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32, Composite Simple, CompositeArray1 Simple, Composite Nested, CompositeArray1 Nested, Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32, Composite Simple, CompositeArray1 Simple, Composite Nested, CompositeArray1 Nested, Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32))
+  , rowTest td (u::(Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32, Composite Simple, CompositeArray1 Simple, Composite Nested, CompositeArray1 Nested, Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32, Composite Simple, CompositeArray1 Simple, Composite Nested, CompositeArray1 Nested, Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, U.UUID))
+  , rowTest td (u::(Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32, Composite Simple, CompositeArray1 Simple, Composite Nested, CompositeArray1 Nested, Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, Day, Array1 Int32, Composite Simple, CompositeArray1 Simple, Composite Nested, CompositeArray1 Nested, Int16, Int32, Int64, Float, Double, Bool, AsciiChar, Word8, String0, BS.ByteString, T.Text, BS.ByteString, U.UUID, Day))
   ]
   where
     u = undefined

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -431,7 +431,7 @@ uuidTest td = testCase "UUID encoding / decoding test" $ do
   let uuidStr = "550e8400-e29b-41d4-a716-446655440000"
       (Just uuid) = U.fromText uuidStr
   runTestEnv td defaultTransactionSettings $ do
-    runSQL_ $ mkSQL $ "SELECT '" <> uuidStr <> "' :: uuid"
+    runSQL_ $ mkSQL $ "SELECT '" `mappend` uuidStr `mappend` "' :: uuid"
     uuid2 <- fetchOne runIdentity
     assertEqual "UUID is decoded correctly" uuid uuid2 (==)
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -28,7 +28,7 @@ import Test.QuickCheck.Gen
 import TextShow
 import qualified Data.ByteString as BS
 import qualified Data.Text as T
-import qualified Data.UUID as U
+import qualified Data.UUID.Types as U
 
 import Data.Monoid.Utils
 import Database.PostgreSQL.PQTypes

--- a/test/Test/QuickCheck/Arbitrary/Instances.hs
+++ b/test/Test/QuickCheck/Arbitrary/Instances.hs
@@ -14,7 +14,7 @@ import qualified Data.ByteString as BS
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import qualified Data.Vector as V
-import qualified Data.UUID as U
+import qualified Data.UUID.Types as U
 
 import Database.PostgreSQL.PQTypes
 

--- a/test/Test/QuickCheck/Arbitrary/Instances.hs
+++ b/test/Test/QuickCheck/Arbitrary/Instances.hs
@@ -14,6 +14,7 @@ import qualified Data.ByteString as BS
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import qualified Data.Vector as V
+import qualified Data.UUID as U
 
 import Database.PostgreSQL.PQTypes
 
@@ -50,6 +51,13 @@ instance Arbitrary BS.ByteString where
 
 instance Arbitrary T.Text where
   arbitrary = T.pack . unString0 <$> arbitrary
+
+uuidFromWords :: (Word32, Word32, Word32, Word32) -> U.UUID
+uuidFromWords (a,b,c,d) = U.fromWords a b c d
+
+instance Arbitrary U.UUID where
+  arbitrary = uuidFromWords <$> arbitrary
+  shrink = map uuidFromWords . shrink . U.toWords
 
 ----------------------------------------
 


### PR DESCRIPTION
This PR implements UUID format for hpqtypes. It parses the `PGuuid` type from libpqtypes with some subtle behavior, and convert it to and from the Haskell `UUID` type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scrive/hpqtypes/17)
<!-- Reviewable:end -->
