### PR TITLE
Rectify `mkSQL`'s documentation

### DIFF
--- a/src/Database/PostgreSQL/PQTypes/SQL.hs
+++ b/src/Database/PostgreSQL/PQTypes/SQL.hs
@@ -73,7 +73,7 @@ instance Show SQL where
 
 ----------------------------------------
 
--- | Convert 'ByteString' to 'SQL'.
+-- | Convert a 'Text' SQL string to the 'SQL' type.
 mkSQL :: T.Text -> SQL
 mkSQL = SQL . S.singleton . SqlString
 


### PR DESCRIPTION
This PR rectifies `mkSQL`'s documentation that references `ByteString` whereas the input type is `Text`