### PR TITLE
Add runQuery variants ensuring 1 or >0 rows affected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# hpqtypes-1.9.2.2 (2021-11-18)
+* Add runQuery1_, runSQL1_, runQueryNot0_, runSQLNot0_ to ensure the query has
+  affected either exactly one row or at least one row.
+
 # hpqtypes-1.9.2.1 (2021-11-04)
 * Improve an SQL query that gets information about composite types.
 

--- a/hpqtypes.cabal
+++ b/hpqtypes.cabal
@@ -93,6 +93,7 @@ library
                      , Database.PostgreSQL.PQTypes.Utils
                      , Database.PostgreSQL.PQTypes.FromSQL
                      , Database.PostgreSQL.PQTypes.Array
+                     , Database.PostgreSQL.PQTypes.Exception
                      , Database.PostgreSQL.PQTypes.Fold
                      , Database.PostgreSQL.PQTypes.FromRow
                      , Database.PostgreSQL.PQTypes.JSON

--- a/hpqtypes.cabal
+++ b/hpqtypes.cabal
@@ -1,5 +1,5 @@
 name:                hpqtypes
-version:             1.9.2.1
+version:             1.9.2.2
 synopsis:            Haskell bindings to libpqtypes
 
 description:         Efficient and easy-to-use bindings to (slightly modified)

--- a/src/Database/PostgreSQL/PQTypes/Exception.hs
+++ b/src/Database/PostgreSQL/PQTypes/Exception.hs
@@ -1,0 +1,25 @@
+module Database.PostgreSQL.PQTypes.Exception
+  ( DBException(..)
+  , rethrowWithContext
+  , throwDB
+  ) where
+
+import Control.Exception
+import Control.Monad.Catch
+
+import Database.PostgreSQL.PQTypes.Class
+import Database.PostgreSQL.PQTypes.Internal.Exception
+import Database.PostgreSQL.PQTypes.SQL.Class
+
+-- | When given 'DBException', throw it immediately. Otherwise
+-- wrap it in 'DBException' with the current query context first.
+{-# INLINABLE throwDB #-}
+throwDB :: (Exception e, MonadDB m, MonadThrow m) => e -> m a
+throwDB e = case fromException $ toException e of
+  Just (dbe::DBException) -> throwM dbe
+  Nothing -> do
+    SomeSQL sql <- getLastQuery
+    throwM DBException {
+      dbeQueryContext = sql
+    , dbeError = e
+    }

--- a/src/Database/PostgreSQL/PQTypes/Fold.hs
+++ b/src/Database/PostgreSQL/PQTypes/Fold.hs
@@ -12,10 +12,11 @@ import Control.Monad.Catch
 import qualified Data.Foldable as F
 
 import Database.PostgreSQL.PQTypes.Class
+import Database.PostgreSQL.PQTypes.Exception
 import Database.PostgreSQL.PQTypes.FromRow
+import Database.PostgreSQL.PQTypes.Internal.Exception
 import Database.PostgreSQL.PQTypes.Internal.Error
 import Database.PostgreSQL.PQTypes.Internal.QueryResult
-import Database.PostgreSQL.PQTypes.Utils
 
 -- | Get current 'QueryResult' or throw an exception if there isn't one.
 {-# INLINABLE queryResult #-}

--- a/src/Database/PostgreSQL/PQTypes/Internal/Exception.hs
+++ b/src/Database/PostgreSQL/PQTypes/Internal/Exception.hs
@@ -4,6 +4,7 @@ module Database.PostgreSQL.PQTypes.Internal.Exception (
   , rethrowWithContext
   ) where
 
+import Control.Monad.Catch
 import qualified Control.Exception as E
 
 import Database.PostgreSQL.PQTypes.SQL.Class

--- a/src/Database/PostgreSQL/PQTypes/Utils.hs
+++ b/src/Database/PostgreSQL/PQTypes/Utils.hs
@@ -4,10 +4,14 @@ module Database.PostgreSQL.PQTypes.Utils (
   , runQuery_
   , runQuery01
   , runQuery01_
+  , runQuery1_
+  , runQueryNot0_
   , runSQL
   , runSQL_
   , runSQL01
   , runSQL01_
+  , runSQL1_
+  , runSQLNot0_
   -- Internal.Utils
   , hpqTypesError
   ) where
@@ -67,6 +71,30 @@ runQuery01 sql = do
 runQuery01_ :: (IsSQL sql, MonadDB m, MonadThrow m) => sql -> m ()
 runQuery01_ = void . runQuery01
 
+-- | Specialization of 'runQuery' that checks whether affected/returned
+-- number of rows is exactly 1.
+-- Otherwise, 'AffectedRowsMismatch' exception is thrown.
+{-# INLINABLE runQuery1_ #-}
+runQuery1_ :: (IsSQL sql, MonadDB m, MonadThrow m) => sql -> m ()
+runQuery1_ sql = do
+  n <- runQuery sql
+  when (n /= 1) $ throwDB AffectedRowsMismatch {
+    rowsExpected = [(1, 1)]
+  , rowsDelivered = n
+  }
+
+-- | Specialization of 'runQuery' that checks whether affected/returned
+-- number of rows is greater than 0.
+-- Otherwise, 'AffectedRowsMismatch' exception is thrown.
+{-# INLINABLE runQueryNot0_ #-}
+runQueryNot0_ :: (IsSQL sql, MonadDB m, MonadThrow m) => sql -> m ()
+runQueryNot0_ sql = do
+  n <- runQuery sql
+  when (n == 0) $ throwDB AffectedRowsMismatch {
+    rowsExpected = []
+  , rowsDelivered = 0
+  }
+
 ----------------------------------------
 
 -- | Specialization of 'runQuery' to 'SQL' type.
@@ -88,3 +116,13 @@ runSQL01 = runQuery01
 {-# INLINABLE runSQL01_ #-}
 runSQL01_ :: (MonadDB m, MonadThrow m) => SQL -> m ()
 runSQL01_ = runQuery01_
+
+-- | Specialization of 'runQuery1_' to 'SQL' type.
+{-# INLINABLE runSQL1_ #-}
+runSQL1_ :: (MonadDB m, MonadThrow m) => SQL -> m ()
+runSQL1_ = runQuery1_
+
+-- | Specialization of 'runQueryNot0_' to 'SQL' type.
+{-# INLINABLE runSQLNot0_ #-}
+runSQLNot0_ :: (MonadDB m, MonadThrow m) => SQL -> m ()
+runSQLNot0_ = runQuery01_

--- a/src/Database/PostgreSQL/PQTypes/Utils.hs
+++ b/src/Database/PostgreSQL/PQTypes/Utils.hs
@@ -91,7 +91,7 @@ runQueryNot0_ :: (IsSQL sql, MonadDB m, MonadThrow m) => sql -> m ()
 runQueryNot0_ sql = do
   n <- runQuery sql
   when (n == 0) $ throwDB AffectedRowsMismatch {
-    rowsExpected = []
+    rowsExpected = [(1, maxBound)]
   , rowsDelivered = 0
   }
 

--- a/src/Database/PostgreSQL/PQTypes/Utils.hs
+++ b/src/Database/PostgreSQL/PQTypes/Utils.hs
@@ -3,15 +3,23 @@ module Database.PostgreSQL.PQTypes.Utils (
   , raw
   , runQuery_
   , runQuery01
+  , runQuery01OrElse
   , runQuery01_
+  , runQuery01OrElse_
   , runQuery1_
+  , runQuery1OrElse_
   , runQueryNot0_
+  , runQueryNot0OrElse_
   , runSQL
   , runSQL_
   , runSQL01
+  , runSQL01OrElse
   , runSQL01_
+  , runSQL01OrElse_
   , runSQL1_
+  , runSQL1OrElse_
   , runSQLNot0_
+  , runSQLNot0OrElse_
   -- Internal.Utils
   , hpqTypesError
   ) where
@@ -55,16 +63,31 @@ runQuery_ = void . runQuery
 
 -- | Specialization of 'runQuery' that checks whether affected/returned
 -- number of rows is in range [0, 1] and returns appropriate 'Bool' value.
+-- Otherwise, the given exception is thrown.
+{-# INLINABLE runQuery01OrElse #-}
+runQuery01OrElse
+  :: (Exception e, IsSQL sql, MonadDB m, MonadThrow m) => (Int -> e) -> sql -> m Bool
+runQuery01OrElse f sql = do
+  n <- runQuery sql
+  when (n > 1) $ throwDB (f n)
+  return $ n == 1
+
+-- | Specialization of 'runQuery' that checks whether affected/returned
+-- number of rows is in range [0, 1] and returns appropriate 'Bool' value.
 -- Otherwise, 'AffectedRowsMismatch' exception is thrown.
 {-# INLINABLE runQuery01 #-}
 runQuery01 :: (IsSQL sql, MonadDB m, MonadThrow m) => sql -> m Bool
-runQuery01 sql = do
-  n <- runQuery sql
-  when (n > 1) $ throwDB AffectedRowsMismatch {
+runQuery01 = runQuery01OrElse $ \n ->
+  AffectedRowsMismatch {
     rowsExpected = [(0, 1)]
   , rowsDelivered = n
   }
-  return $ n == 1
+
+-- | Specialization of 'runQuery01OrElse' that discards the result.
+{-# INLINABLE runQuery01OrElse_ #-}
+runQuery01OrElse_
+  :: (Exception e, IsSQL sql, MonadDB m, MonadThrow m) => (Int -> e) -> sql -> m ()
+runQuery01OrElse_ f = void . runQuery01OrElse f
 
 -- | Specialization of 'runQuery01' that discards the result.
 {-# INLINABLE runQuery01_ #-}
@@ -73,24 +96,42 @@ runQuery01_ = void . runQuery01
 
 -- | Specialization of 'runQuery' that checks whether affected/returned
 -- number of rows is exactly 1.
+-- Otherwise, the given exception is thrown.
+{-# INLINABLE runQuery1OrElse_ #-}
+runQuery1OrElse_
+  :: (Exception e, IsSQL sql, MonadDB m, MonadThrow m) => (Int -> e) -> sql -> m ()
+runQuery1OrElse_ f sql = do
+  n <- runQuery sql
+  when (n /= 1) $ throwDB (f n)
+
+-- | Specialization of 'runQuery' that checks whether affected/returned
+-- number of rows is exactly 1.
 -- Otherwise, 'AffectedRowsMismatch' exception is thrown.
 {-# INLINABLE runQuery1_ #-}
 runQuery1_ :: (IsSQL sql, MonadDB m, MonadThrow m) => sql -> m ()
-runQuery1_ sql = do
-  n <- runQuery sql
-  when (n /= 1) $ throwDB AffectedRowsMismatch {
+runQuery1_ = runQuery1OrElse_ $ \n ->
+  AffectedRowsMismatch {
     rowsExpected = [(1, 1)]
   , rowsDelivered = n
   }
 
 -- | Specialization of 'runQuery' that checks whether affected/returned
 -- number of rows is greater than 0.
+-- Otherwise, the given exception is thrown.
+{-# INLINABLE runQueryNot0OrElse_ #-}
+runQueryNot0OrElse_
+  :: (Exception e, IsSQL sql, MonadDB m, MonadThrow m) => (Int -> e) -> sql -> m ()
+runQueryNot0OrElse_ f sql = do
+  n <- runQuery sql
+  when (n == 0) $ throwDB (f n)
+
+-- | Specialization of 'runQuery' that checks whether affected/returned
+-- number of rows is greater than 0.
 -- Otherwise, 'AffectedRowsMismatch' exception is thrown.
 {-# INLINABLE runQueryNot0_ #-}
 runQueryNot0_ :: (IsSQL sql, MonadDB m, MonadThrow m) => sql -> m ()
-runQueryNot0_ sql = do
-  n <- runQuery sql
-  when (n == 0) $ throwDB AffectedRowsMismatch {
+runQueryNot0_ = runQueryNot0OrElse_ $ \n ->
+  AffectedRowsMismatch {
     rowsExpected = [(1, maxBound)]
   , rowsDelivered = 0
   }
@@ -112,17 +153,41 @@ runSQL_ = runQuery_
 runSQL01 :: (MonadDB m, MonadThrow m) => SQL -> m Bool
 runSQL01 = runQuery01
 
+-- | Specialization of 'runQuery01OrElse' to 'SQL' type.
+{-# INLINABLE runSQL01OrElse #-}
+runSQL01OrElse
+  :: (Exception e, MonadDB m, MonadThrow m) => (Int -> e) -> SQL -> m Bool
+runSQL01OrElse = runQuery01OrElse
+
 -- | Specialization of 'runQuery01_' to 'SQL' type.
 {-# INLINABLE runSQL01_ #-}
 runSQL01_ :: (MonadDB m, MonadThrow m) => SQL -> m ()
 runSQL01_ = runQuery01_
+
+-- | Specialization of 'runQuery01OrElse_' to 'SQL' type.
+{-# INLINABLE runSQL01OrElse_ #-}
+runSQL01OrElse_
+  :: (Exception e, MonadDB m, MonadThrow m) => (Int -> e) -> SQL -> m ()
+runSQL01OrElse_ = runQuery01OrElse_
 
 -- | Specialization of 'runQuery1_' to 'SQL' type.
 {-# INLINABLE runSQL1_ #-}
 runSQL1_ :: (MonadDB m, MonadThrow m) => SQL -> m ()
 runSQL1_ = runQuery1_
 
+-- | Specialization of 'runQuery1OrElse_' to 'SQL' type.
+{-# INLINABLE runSQL1OrElse_ #-}
+runSQL1OrElse_
+  :: (Exception e, MonadDB m, MonadThrow m) => (Int -> e) -> SQL -> m ()
+runSQL1OrElse_ = runQuery1OrElse_
+
 -- | Specialization of 'runQueryNot0_' to 'SQL' type.
 {-# INLINABLE runSQLNot0_ #-}
 runSQLNot0_ :: (MonadDB m, MonadThrow m) => SQL -> m ()
 runSQLNot0_ = runQuery01_
+
+-- | Specialization of 'runQueryNot0OrElse_' to 'SQL' type.
+{-# INLINABLE runSQLNot0OrElse_ #-}
+runSQLNot0OrElse_
+  :: (Exception e, MonadDB m, MonadThrow m) => (Int -> e) -> SQL -> m ()
+runSQLNot0OrElse_ = runQuery01OrElse_


### PR DESCRIPTION
This is to serve as replacements for `kRun*` functions (to be removed from `hpqtypes-extras`) but with no attempts to explain why it didn't work.