### PR TITLE
Switch from `readline` to `haskeline`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes:
       60
     container:
-      image: buildpack-deps:bionic
+      image: buildpack-deps:jammy
     services:
       postgres:
         image: postgres:14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# hpqtypes-1.12.1.0 (????-??-??)
+* Switch from `readline` to `haskeline`, to make example compile with newer
+  Cabal versions.
+
 # hpqtypes-1.12.0.0 (2024-03-18)
 * Drop support for GHC 8.8.
 * Attach `CallStack` and `BackendPid` to `DBException`.

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,3 +1,4 @@
+distribution:   jammy
 branches:       master
 doctest:        False
 tests:          True

--- a/hpqtypes.cabal
+++ b/hpqtypes.cabal
@@ -197,7 +197,7 @@ test-suite hpqtypes-tests
                      , monad-control >= 1.0.3
                      , mtl >= 2.1
                      , random >= 1.0
-                     , readline >= 1.0.3.0
+                     , haskeline
                      , resource-pool >= 0.4
                      , scientific
                      , test-framework >= 0.8


### PR DESCRIPTION
Apparently `readline` doesn't build with newer versions of cabal.
