### PR TITLE
Fix a bug in deserialization of Integer values

### DIFF
--- a/src/Database/PostgreSQL/PQTypes/Internal/Utils.hs
+++ b/src/Database/PostgreSQL/PQTypes/Internal/Utils.hs
@@ -96,10 +96,24 @@ numericVarToInteger :: NumericVar -> IO Integer
 numericVarToInteger NumericVar {..}
   | numVarDscale /= 0 = hpqTypesError "not an integer"
   | numVarSign == c_NUMERIC_NAN = hpqTypesError "not a number"
-  | numVarSign == c_NUMERIC_POS = mkInteger 0 numVarDigits numVarNdigits
-  | numVarSign == c_NUMERIC_NEG = negate <$> mkInteger 0 numVarDigits numVarNdigits
+  | numVarNdigits > numVarWeight + 1 =
+      hpqTypesError $
+        "digits after the decimal point (ndigits: "
+          ++ show numVarNdigits
+          ++ ", weight: "
+          ++ show numVarWeight
+          ++ ")"
+  | numVarSign == c_NUMERIC_POS = scale <$> mkInteger 0 numVarDigits numVarNdigits
+  | numVarSign == c_NUMERIC_NEG = negate . scale <$> mkInteger 0 numVarDigits numVarNdigits
   | otherwise = hpqTypesError $ "unexpected sign: " ++ show numVarSign
   where
+    -- The wire value is Σ digits[i] * 10000^(weight - i) and the server strips
+    -- trailing zero digit groups, so ndigits can be smaller than weight + 1.
+    scale :: Integer -> Integer
+    scale acc = case numVarWeight + 1 - numVarNdigits of
+      0 -> acc
+      n -> acc * 10000 ^ n
+
     mkInteger :: Integer -> Ptr CShort -> CShort -> IO Integer
     mkInteger acc ptr = \case
       0 -> pure acc

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -539,6 +539,41 @@ uuidTest td = testCase "UUID encoding / decoding test" $ do
     uuidStr2 <- fetchOne runIdentity
     assertEqual "UUID is encoded correctly" uuidStr uuidStr2 (==)
 
+integerTest :: TestData -> Test
+integerTest td = testCase "Integer decoding from numeric works"
+  . runTestEnv td defaultTransactionSettings
+  . forM_ values
+  $ \n -> do
+    -- The server strips trailing zero base-10000 digit groups from the wire
+    -- representation of numeric, so values that are multiples of 10000 arrive
+    -- with fewer digits than their weight indicates.
+    runSQL_ . mkSQL $ "SELECT " <> showt n <> " :: numeric"
+    n' <- fetchOne runIdentity
+    assertEqualEq ("Integer" <+> show n <+> "is decoded correctly") n n'
+
+    runQuery_ $ rawSQL "SELECT $1" (Identity n)
+    n'' <- fetchOne runIdentity
+    assertEqualEq ("Integer" <+> show n <+> "roundtrips correctly") n n''
+  where
+    values :: [Integer]
+    values =
+      [ 0
+      , 1
+      , -1
+      , 9999
+      , 10000
+      , -10000
+      , 10001
+      , 99990000
+      , 100000000
+      , 1000000000000
+      , -1000000000000
+      , 123400005678
+      , 10 ^ (100 :: Int)
+      , negate $ 10 ^ (100 :: Int)
+      , 10 ^ (100 :: Int) + 1
+      ]
+
 xmlTest :: TestData -> Test
 xmlTest td = testCase "Put and get XML value works"
   . runTestEnv td defaultTransactionSettings
@@ -626,6 +661,7 @@ tests td =
   , queryInterruptionTest td
   , cursorTest td
   , uuidTest td
+  , integerTest td
   , onDemandTest td
   , transactionTest td ReadCommitted
   , transactionTest td RepeatableRead


### PR DESCRIPTION
It used to strip zeros from numbers that divide by 10000^n for n > 0.